### PR TITLE
Suggested idea to refactor Dispatcher commands to be more flexible wh…

### DIFF
--- a/Source/Ivxr.SePlugin/Control/Dispatcher.cs
+++ b/Source/Ivxr.SePlugin/Control/Dispatcher.cs
@@ -5,17 +5,13 @@ using Iv4xr.SePlugin.Json;
 
 namespace Iv4xr.SePlugin.Control
 {
-    using CommandDict = Dictionary<String, IStringCommand>;
+    using CommandDict = Dictionary<string, IStringCommand>;
 
     public class Dispatcher
     {
         public ILog Log { get; set; }
 
         private readonly RequestQueue m_requestQueue;
-
-        private readonly IObserver m_observer;
-
-        private readonly ICharacterController m_controller;
 
         private readonly Jsoner m_jsoner = new Jsoner();
 
@@ -26,14 +22,8 @@ namespace Iv4xr.SePlugin.Control
         public Dispatcher(RequestQueue requestQueue, IObserver observer, ICharacterController controller, CommandDict commands = null)
         {
             m_requestQueue = requestQueue;
-            m_observer = observer;
-            m_controller = controller;
             m_context = new DispatcherContext(observer, controller);
-            m_commands = commands;
-            if (m_commands == null)
-            {
-                m_commands = DefaultCommands();
-            }
+            m_commands = commands ?? DefaultCommands();
         }
 
         public void AddCommand(IStringCommand command)
@@ -83,7 +73,7 @@ namespace Iv4xr.SePlugin.Control
         private string ProcessSingleRequest(RequestItem request)
         {
             // Skip prefix "{\"Cmd\":\"AGENTCOMMAND\",\"Arg\":{\"Cmd\":\""
-            var commandName = request.Message.Substring(36, 20).Split(new string[] { "\"" }, StringSplitOptions.None)[0];
+            var commandName = request.Message.Substring(36, 20).Split(new[] { "\"" }, StringSplitOptions.None)[0];
             Log?.WriteLine($"{nameof(Dispatcher)} command prefix: '{commandName}'.");
 
             if (m_commands.ContainsKey(commandName))

--- a/Source/Ivxr.SePlugin/Control/Dispatcher.cs
+++ b/Source/Ivxr.SePlugin/Control/Dispatcher.cs
@@ -1,8 +1,6 @@
 ﻿using Iv4xr.PluginLib;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
 using Iv4xr.SePlugin.Json;
 using Iv4xr.SePlugin.WorldModel;
 using Iv4xr.PluginLib.Comm;
@@ -10,86 +8,186 @@ using VRageMath;
 
 namespace Iv4xr.SePlugin.Control
 {
-	public class Dispatcher
-	{
-		public ILog Log { get; set; }
 
-		private readonly RequestQueue m_requestQueue;
+    using CommandDict = Dictionary<String, StringCommand>;
 
-		private readonly IObserver m_observer;
+    public class DispatcherContext
+    {
+        public readonly IObserver observer;
+        public readonly ICharacterController characterController;
 
-		private readonly ICharacterController m_controller;
+        public DispatcherContext(IObserver observer, ICharacterController characterController)
+        {
+            this.observer = observer;
+            this.characterController = characterController;
+        }
+    }
 
-		private readonly Jsoner m_jsoner = new Jsoner();
+    public interface StringCommand
+    {
+        string Cmd { get; }
+        string Execute(string message, DispatcherContext m_context, Jsoner m_jsoner);
+    }
 
-		public Dispatcher(RequestQueue requestQueue, IObserver observer, ICharacterController controller)
-		{
-			m_requestQueue = requestQueue;
-			m_observer = observer;
-			m_controller = controller;
-		}
+    public abstract class DispatcherCommand<I, O> : StringCommand
+        where I : class
+        where O : class
+    {
+        public string Cmd { get; }
 
-		public void ProcessRequests()
-		{
-			while (m_requestQueue.Requests.TryDequeue(out RequestItem request))
-			{
-				string jsonReply;
+        public DispatcherCommand(string cmd)
+        {
+            this.Cmd = cmd;
+        }
 
-				try
-				{
-					jsonReply = ProcessSingleRequest(request);
-				}
-				catch (Exception ex)
-				{
-					Log.Exception(ex, "Error processing a request");
-					Log.WriteLine($"Full request: \"{request.Message}\"");
-					jsonReply = "false";  // Simple error response, details can be learned from the log.
-				}
+        public string Execute(string message, DispatcherContext m_context, Jsoner m_jsoner)
 
-				m_requestQueue.Replies.Add(
-					new RequestItem(request.ClientStream, message: jsonReply));
-			}
-		}
+        {
+            var inputData = m_jsoner.ToObject<I>(message);
+            var outputData = Execute(m_context, inputData);
+            return m_jsoner.ToJson(outputData);
+        }
 
-		private string ProcessSingleRequest(RequestItem request)
-		{
-			// Skip prefix "{\"Cmd\":\"AGENTCOMMAND\",\"Arg\":{\"Cmd\":\""
-			var commandName = request.Message.Substring(36, 10);
+        public abstract O Execute(DispatcherContext context, I data);
+    }
 
-			Log?.WriteLine($"{nameof(Dispatcher)} command prefix: '{commandName}'.");
+    public class ObserveCommand : DispatcherCommand<SeRequestShell<AgentCommand<ObservationArgs>>, SeObservation>
+    {
 
-			if (commandName.StartsWith("OBSERVE") || commandName.StartsWith("DONOTHING"))  // DONOTHING is obsolete.
-			{
-				var requestShell = m_jsoner.ToObject<SeRequestShell<AgentCommand<ObservationArgs>>>(request.Message);
+        public ObserveCommand() : base("OBSERVE")
+        {}
 
-				return m_jsoner.ToJson(m_observer.GetObservation(requestShell.Arg.Arg));
-			}
-			else if (commandName.StartsWith("MOVE_ROTAT"))  // MOVE_ROTATE
-			{
-				var requestShell = m_jsoner.ToObject<SeRequestShell<AgentCommand<MoveAndRotateArgs>>>(request.Message);
+        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<ObservationArgs>> data)
+        {
+            return context.observer.GetObservation(data.Arg.Arg);
+        }
+    }
 
-				m_controller.Move(requestShell.Arg.Arg);
-			}
-			else if (commandName.StartsWith("MOVETOWARD"))  // TODO(PP): Remove.
-			{
-				var requestShell = m_jsoner.ToObject<SeRequestShell<AgentCommand<MoveCommandArgs>>>(request.Message);
-				var moveCommandArgs = requestShell.Arg.Arg;
+    public class MoveAndRotateCommand : DispatcherCommand<SeRequestShell<AgentCommand<MoveAndRotateArgs>>, SeObservation>
+    {
+        public MoveAndRotateCommand() : base("MOVE_ROTATE")
+        {}
 
-				Log?.WriteLine($"Move indicator: {moveCommandArgs.MoveIndicator}");
-				m_controller.Move(moveCommandArgs.MoveIndicator, Vector2.Zero, 0.0f);
-			}
-			else if (commandName.StartsWith("INTERACT"))
-			{ 
-				var requestShell = m_jsoner.ToObject<SeRequestShell<AgentCommand<InteractionArgs>>>(request.Message);
+        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<MoveAndRotateArgs>> data)
+        {
+            context.characterController.Move(data.Arg.Arg);
+            return context.observer.GetObservation();
+        }
+    }
 
-				m_controller.Interact(requestShell.Arg.Arg);
-			}
-			else
-			{
-				throw new NotImplementedException($"Unknown agent command: {commandName}");
-			}
+    public class MoveTowardCommand : DispatcherCommand<SeRequestShell<AgentCommand<MoveCommandArgs>>, SeObservation>
+    {
+        public MoveTowardCommand() : base("MOVETOWARD")
+        {}
 
-			return m_jsoner.ToJson(m_observer.GetObservation());
-		}
-	}
+        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<MoveCommandArgs>> data)
+        {
+            context.characterController.Move(data.Arg.Arg.MoveIndicator, Vector2.Zero, 0.0f);
+            return context.observer.GetObservation();
+
+        }
+    }
+
+    public class InteractCommand : DispatcherCommand<SeRequestShell<AgentCommand<InteractionArgs>>, SeObservation>
+    {
+        public InteractCommand() : base("INTERACT")
+        {}
+
+        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<InteractionArgs>> data)
+        {
+            context.characterController.Interact(data.Arg.Arg);
+            return context.observer.GetObservation();
+        }
+    }
+
+
+    public class Dispatcher
+    {
+        public ILog Log { get; set; }
+
+        private readonly RequestQueue m_requestQueue;
+
+        private readonly IObserver m_observer;
+
+        private readonly ICharacterController m_controller;
+
+        private readonly Jsoner m_jsoner = new Jsoner();
+
+        private readonly DispatcherContext m_context;
+
+        private readonly CommandDict m_commands;
+
+        public Dispatcher(RequestQueue requestQueue, IObserver observer, ICharacterController controller, CommandDict commands = null)
+        {
+            m_requestQueue = requestQueue;
+            m_observer = observer;
+            m_controller = controller;
+            m_context = new DispatcherContext(observer, controller);
+            m_commands = commands;
+            if (m_commands == null)
+            {
+                m_commands = DefaultCommands();
+            }
+        }
+
+        public void AddCommand(StringCommand command)
+        {
+            m_commands[command.Cmd] = command;
+        }
+
+        private CommandDict DefaultCommands()
+        {
+
+            var commandList = new List<StringCommand>
+            {
+                new ObserveCommand(),
+                new MoveAndRotateCommand(),
+                new MoveTowardCommand(),
+                new InteractCommand()
+            };
+            var result = new CommandDict();
+            foreach (var command in commandList)
+            {
+                result[command.Cmd] = command;
+            }
+            return result;
+        }
+
+        public void ProcessRequests()
+        {
+            while (m_requestQueue.Requests.TryDequeue(out RequestItem request))
+            {
+                string jsonReply;
+
+                try
+                {
+                    jsonReply = ProcessSingleRequest(request);
+                }
+                catch (Exception ex)
+                {
+                    Log.Exception(ex, "Error processing a request");
+                    Log.WriteLine($"Full request: \"{request.Message}\"");
+                    jsonReply = "false";  // Simple error response, details can be learned from the log.
+                }
+
+                m_requestQueue.Replies.Add(
+                    new RequestItem(request.ClientStream, message: jsonReply));
+            }
+        }
+
+        private string ProcessSingleRequest(RequestItem request)
+        {
+            // Skip prefix "{\"Cmd\":\"AGENTCOMMAND\",\"Arg\":{\"Cmd\":\""
+            var commandName = request.Message.Substring(36, 20).Split(new string[] { "\"" }, StringSplitOptions.None)[0];
+            Log?.WriteLine($"{nameof(Dispatcher)} command prefix: '{commandName}'.");
+
+            if (m_commands.ContainsKey(commandName))
+            {
+                var command = m_commands[commandName];
+                return command.Execute(request.Message, m_context, m_jsoner);
+            }
+            throw new NotImplementedException($"Unknown agent command: {commandName}");
+
+        }
+    }
 }

--- a/Source/Ivxr.SePlugin/Control/DispatcherCommand.cs
+++ b/Source/Ivxr.SePlugin/Control/DispatcherCommand.cs
@@ -1,7 +1,4 @@
 ﻿using Iv4xr.SePlugin.Json;
-using Iv4xr.SePlugin.WorldModel;
-using Iv4xr.PluginLib.Comm;
-using VRageMath;
 
 namespace Iv4xr.SePlugin.Control
 {
@@ -42,53 +39,5 @@ namespace Iv4xr.SePlugin.Control
         }
 
         public abstract TOutput Execute(DispatcherContext context, TInput data);
-    }
-
-    public class ObserveCommand : DispatcherCommand<SeRequestShell<AgentCommand<ObservationArgs>>, SeObservation>
-    {
-
-        public ObserveCommand() : base("OBSERVE")
-        { }
-
-        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<ObservationArgs>> data)
-        {
-            return context.Observer.GetObservation(data.Arg.Arg);
-        }
-    }
-
-    public class MoveAndRotateCommand : DispatcherCommand<SeRequestShell<AgentCommand<MoveAndRotateArgs>>, SeObservation>
-    {
-        public MoveAndRotateCommand() : base("MOVE_ROTATE")
-        { }
-
-        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<MoveAndRotateArgs>> data)
-        {
-            context.CharacterController.Move(data.Arg.Arg);
-            return context.Observer.GetObservation();
-        }
-    }
-
-    public class MoveTowardCommand : DispatcherCommand<SeRequestShell<AgentCommand<MoveCommandArgs>>, SeObservation>
-    {
-        public MoveTowardCommand() : base("MOVETOWARD")
-        { }
-
-        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<MoveCommandArgs>> data)
-        {
-            context.CharacterController.Move(data.Arg.Arg.MoveIndicator, Vector2.Zero, 0.0f);
-            return context.Observer.GetObservation();
-        }
-    }
-
-    public class InteractCommand : DispatcherCommand<SeRequestShell<AgentCommand<InteractionArgs>>, SeObservation>
-    {
-        public InteractCommand() : base("INTERACT")
-        { }
-
-        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<InteractionArgs>> data)
-        {
-            context.CharacterController.Interact(data.Arg.Arg);
-            return context.Observer.GetObservation();
-        }
     }
 }

--- a/Source/Ivxr.SePlugin/Control/DispatcherCommand.cs
+++ b/Source/Ivxr.SePlugin/Control/DispatcherCommand.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Iv4xr.SePlugin.Json;
+﻿using Iv4xr.SePlugin.Json;
 using Iv4xr.SePlugin.WorldModel;
 using Iv4xr.PluginLib.Comm;
 using VRageMath;
@@ -9,13 +7,13 @@ namespace Iv4xr.SePlugin.Control
 {
     public class DispatcherContext
     {
-        public readonly IObserver m_observer;
-        public readonly ICharacterController m_characterController;
+        public readonly IObserver Observer;
+        public readonly ICharacterController CharacterController;
 
         public DispatcherContext(IObserver observer, ICharacterController characterController)
         {
-            this.m_observer = observer;
-            this.m_characterController = characterController;
+            this.Observer = observer;
+            this.CharacterController = characterController;
         }
     }
 
@@ -31,7 +29,7 @@ namespace Iv4xr.SePlugin.Control
     {
         public string Cmd { get; }
 
-        public DispatcherCommand(string cmd)
+        protected DispatcherCommand(string cmd)
         {
             this.Cmd = cmd;
         }
@@ -54,7 +52,7 @@ namespace Iv4xr.SePlugin.Control
 
         public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<ObservationArgs>> data)
         {
-            return context.m_observer.GetObservation(data.Arg.Arg);
+            return context.Observer.GetObservation(data.Arg.Arg);
         }
     }
 
@@ -65,8 +63,8 @@ namespace Iv4xr.SePlugin.Control
 
         public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<MoveAndRotateArgs>> data)
         {
-            context.m_characterController.Move(data.Arg.Arg);
-            return context.m_observer.GetObservation();
+            context.CharacterController.Move(data.Arg.Arg);
+            return context.Observer.GetObservation();
         }
     }
 
@@ -77,8 +75,8 @@ namespace Iv4xr.SePlugin.Control
 
         public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<MoveCommandArgs>> data)
         {
-            context.m_characterController.Move(data.Arg.Arg.MoveIndicator, Vector2.Zero, 0.0f);
-            return context.m_observer.GetObservation();
+            context.CharacterController.Move(data.Arg.Arg.MoveIndicator, Vector2.Zero, 0.0f);
+            return context.Observer.GetObservation();
         }
     }
 
@@ -89,8 +87,8 @@ namespace Iv4xr.SePlugin.Control
 
         public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<InteractionArgs>> data)
         {
-            context.m_characterController.Interact(data.Arg.Arg);
-            return context.m_observer.GetObservation();
+            context.CharacterController.Interact(data.Arg.Arg);
+            return context.Observer.GetObservation();
         }
     }
 }

--- a/Source/Ivxr.SePlugin/Control/DispatcherCommand.cs
+++ b/Source/Ivxr.SePlugin/Control/DispatcherCommand.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using Iv4xr.SePlugin.Json;
+using Iv4xr.SePlugin.WorldModel;
+using Iv4xr.PluginLib.Comm;
+using VRageMath;
+
+namespace Iv4xr.SePlugin.Control
+{
+    public class DispatcherContext
+    {
+        public readonly IObserver m_observer;
+        public readonly ICharacterController m_characterController;
+
+        public DispatcherContext(IObserver observer, ICharacterController characterController)
+        {
+            this.m_observer = observer;
+            this.m_characterController = characterController;
+        }
+    }
+
+    public interface IStringCommand
+    {
+        string Cmd { get; }
+        string Execute(string message, DispatcherContext context, Jsoner jsoner);
+    }
+
+    public abstract class DispatcherCommand<TInput, TOutput> : IStringCommand
+        where TInput : class
+        where TOutput : class
+    {
+        public string Cmd { get; }
+
+        public DispatcherCommand(string cmd)
+        {
+            this.Cmd = cmd;
+        }
+
+        public string Execute(string message, DispatcherContext context, Jsoner jsoner)
+        {
+            var inputData = jsoner.ToObject<TInput>(message);
+            var outputData = Execute(context, inputData);
+            return jsoner.ToJson(outputData);
+        }
+
+        public abstract TOutput Execute(DispatcherContext context, TInput data);
+    }
+
+    public class ObserveCommand : DispatcherCommand<SeRequestShell<AgentCommand<ObservationArgs>>, SeObservation>
+    {
+
+        public ObserveCommand() : base("OBSERVE")
+        { }
+
+        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<ObservationArgs>> data)
+        {
+            return context.m_observer.GetObservation(data.Arg.Arg);
+        }
+    }
+
+    public class MoveAndRotateCommand : DispatcherCommand<SeRequestShell<AgentCommand<MoveAndRotateArgs>>, SeObservation>
+    {
+        public MoveAndRotateCommand() : base("MOVE_ROTATE")
+        { }
+
+        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<MoveAndRotateArgs>> data)
+        {
+            context.m_characterController.Move(data.Arg.Arg);
+            return context.m_observer.GetObservation();
+        }
+    }
+
+    public class MoveTowardCommand : DispatcherCommand<SeRequestShell<AgentCommand<MoveCommandArgs>>, SeObservation>
+    {
+        public MoveTowardCommand() : base("MOVETOWARD")
+        { }
+
+        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<MoveCommandArgs>> data)
+        {
+            context.m_characterController.Move(data.Arg.Arg.MoveIndicator, Vector2.Zero, 0.0f);
+            return context.m_observer.GetObservation();
+        }
+    }
+
+    public class InteractCommand : DispatcherCommand<SeRequestShell<AgentCommand<InteractionArgs>>, SeObservation>
+    {
+        public InteractCommand() : base("INTERACT")
+        { }
+
+        public override SeObservation Execute(DispatcherContext context, SeRequestShell<AgentCommand<InteractionArgs>> data)
+        {
+            context.m_characterController.Interact(data.Arg.Arg);
+            return context.m_observer.GetObservation();
+        }
+    }
+}

--- a/Source/Ivxr.SePlugin/Control/DispatcherCommandImplementations.cs
+++ b/Source/Ivxr.SePlugin/Control/DispatcherCommandImplementations.cs
@@ -1,0 +1,62 @@
+﻿using Iv4xr.SePlugin.WorldModel;
+using Iv4xr.PluginLib.Comm;
+using VRageMath;
+
+namespace Iv4xr.SePlugin.Control
+{
+    public class ObserveCommand : DispatcherCommand<SeRequestShell<AgentCommand<ObservationArgs>>, SeObservation>
+    {
+        public ObserveCommand() : base("OBSERVE")
+        {
+        }
+
+        public override SeObservation Execute(DispatcherContext context,
+            SeRequestShell<AgentCommand<ObservationArgs>> data)
+        {
+            return context.Observer.GetObservation(data.Arg.Arg);
+        }
+    }
+
+    public class
+        MoveAndRotateCommand : DispatcherCommand<SeRequestShell<AgentCommand<MoveAndRotateArgs>>, SeObservation>
+    {
+        public MoveAndRotateCommand() : base("MOVE_ROTATE")
+        {
+        }
+
+        public override SeObservation Execute(DispatcherContext context,
+            SeRequestShell<AgentCommand<MoveAndRotateArgs>> data)
+        {
+            context.CharacterController.Move(data.Arg.Arg);
+            return context.Observer.GetObservation();
+        }
+    }
+
+    public class MoveTowardCommand : DispatcherCommand<SeRequestShell<AgentCommand<MoveCommandArgs>>, SeObservation>
+    {
+        public MoveTowardCommand() : base("MOVETOWARD")
+        {
+        }
+
+        public override SeObservation Execute(DispatcherContext context,
+            SeRequestShell<AgentCommand<MoveCommandArgs>> data)
+        {
+            context.CharacterController.Move(data.Arg.Arg.MoveIndicator, Vector2.Zero, 0.0f);
+            return context.Observer.GetObservation();
+        }
+    }
+
+    public class InteractCommand : DispatcherCommand<SeRequestShell<AgentCommand<InteractionArgs>>, SeObservation>
+    {
+        public InteractCommand() : base("INTERACT")
+        {
+        }
+
+        public override SeObservation Execute(DispatcherContext context,
+            SeRequestShell<AgentCommand<InteractionArgs>> data)
+        {
+            context.CharacterController.Interact(data.Arg.Arg);
+            return context.Observer.GetObservation();
+        }
+    }
+}


### PR DESCRIPTION
…en adding new commands.

- Not sure about naming conventions, first C# commit.
- Not sure about names overall.
- Not sure where to put all the new classes, all "DispatcherCommand" classes deserve it's own class.
- Solution should behave (almost) exactly as previous (only command string parsing changes), all relevant java tests passing.
- I used auto code formatter and I believe it changed formatting of some of the original code. How is that possible? Do we not use default code formatting rules? We should definitely everyone use same coding convetion and format/autoformatter rules so that autoformat doesn't cause unnecessary diffs.

To add new command:
- Implement StringCommand interface or more convenient DispatcherCommand abstract class.
- Call Dispatcher.AddCommand() and pass implemented class instance.