### PR TITLE
Add a pair of interaction types: Begin, end using tool.

### DIFF
--- a/Source/Ivxr.SePlugin/Control/CharacterController.cs
+++ b/Source/Ivxr.SePlugin/Control/CharacterController.cs
@@ -19,7 +19,7 @@ namespace Iv4xr.SePlugin.Control
 
     public class CharacterController : ICharacterController
     {
-        private IGameSession m_session;
+        private readonly IGameSession m_session;
 
         public CharacterController(IGameSession session)
         {
@@ -48,10 +48,30 @@ namespace Iv4xr.SePlugin.Control
             {
                 PlaceItem();
             }
+            else if (args.InteractionType == InteractionType.BEGIN_USE)
+            {
+                BeginUseTool();
+            }
+            else if (args.InteractionType == InteractionType.END_USE)
+            {
+                EndUseTool();
+            }
             else
             {
                 throw new ArgumentException("Unknown or not implemented interaction type.");
             }
+        }
+
+        private void BeginUseTool()
+        {
+            var entityController = GetEntityController();
+            entityController.ControlledEntity.BeginShoot(MyShootActionEnum.PrimaryAction);
+        }
+
+        private void EndUseTool()
+        {
+            var entityController = GetEntityController();
+            entityController.ControlledEntity.EndShoot(MyShootActionEnum.PrimaryAction);
         }
 
         private void PlaceItem()

--- a/Source/Ivxr.SePlugin/WorldModel/AgentCommand.cs
+++ b/Source/Ivxr.SePlugin/WorldModel/AgentCommand.cs
@@ -62,7 +62,9 @@ namespace Iv4xr.SePlugin.WorldModel
     public enum InteractionType
     {
         EQUIP,
-        PLACE
+        PLACE,
+        BEGIN_USE,
+        END_USE
     }
 
     public class InteractionArgs
@@ -73,11 +75,11 @@ namespace Iv4xr.SePlugin.WorldModel
         public bool AllowSizeChange;
     }
 
-    public class AgentCommand<ArgumentType>
+    public class AgentCommand<TArgument>
     {
         public string Cmd;
         public string AgentId;
         public string TargetId;
-        public ArgumentType Arg;
+        public TArgument Arg;
     }
 }


### PR DESCRIPTION
Missing in this version: Action number (primary/secondary/tertiary).

Probably would make sense as a different request because it will have different params than the toolbar config requests. I see that json-rpc would make sense for this.