### PR TITLE
Unifying Entities and OrientedPositions: Id, Position, Orientations

### DIFF
--- a/Source/Helpers/SeServerMock/Mocks/MockObserver.cs
+++ b/Source/Helpers/SeServerMock/Mocks/MockObserver.cs
@@ -11,17 +11,6 @@ namespace SeServerMock.Mocks
 
         public Observation GetObservation()
         {
-            var entity = new Entity()
-            {
-                    Id = "Ente",
-                    Position = new PlainVec3D(3, 2, 1)
-            };
-
-            var entities = new List<Entity>
-            {
-                    entity
-            };
-
             var block = new Block()
             {
                     Id = "blk",
@@ -48,9 +37,8 @@ namespace SeServerMock.Mocks
 
             return new Observation()
             {
-                    AgentID = "Mock",
+                    Id = "Mock",
                     Position = new PlainVec3D(4, 2, 0),
-                    Entities = entities,
                     Grids = grids
             };
         }

--- a/Source/Ivxr.SePlugin/Control/LowLevelObserver.cs
+++ b/Source/Ivxr.SePlugin/Control/LowLevelObserver.cs
@@ -44,7 +44,7 @@ namespace Iv4xr.SePlugin.Control
             var orientation = Character.PositionComp.GetOrientation();
             return new Observation
             {
-                AgentID = "se0",
+                Id = "se0",
                 Position = new PlainVec3D(GetPlayerPosition()), // Consider reducing allocations.
                 OrientationForward = new PlainVec3D(orientation.Forward),
                 OrientationUp = new PlainVec3D(orientation.Up),

--- a/Source/Ivxr.SePlugin/Control/SeEntityBuilder.cs
+++ b/Source/Ivxr.SePlugin/Control/SeEntityBuilder.cs
@@ -57,12 +57,16 @@ namespace Iv4xr.SePlugin.Control
         {
             var seBlocks = CreateGridBLocks(FoundBlocks(sourceGrid, sphere), mode).ToList();
             var position = sourceGrid.PositionComp.GetPosition();
+            var orientationUp = sourceGrid.PositionComp.GetOrientation().Up;
+            var orientationForward = sourceGrid.PositionComp.GetOrientation().Forward;
 
             return new CubeGrid
             {
                 Id = sourceGrid.DisplayName,
-                Position = new PlainVec3D(position),
-                Blocks = seBlocks
+                Position = position.ToPlain(),
+                Blocks = seBlocks,
+                OrientationForward = orientationForward.ToPlain(),
+                OrientationUp = orientationUp.ToPlain()
             };
         }
 

--- a/Source/Ivxr.SePlugin/MyExtensions.cs
+++ b/Source/Ivxr.SePlugin/MyExtensions.cs
@@ -4,11 +4,17 @@ using Iv4xr.SePlugin.WorldModel;
 using Sandbox.Game.Multiplayer;
 using Sandbox.Game.Screens.Helpers;
 using Sandbox.Game.World;
+using VRageMath;
 
 namespace Iv4xr.SePlugin
 {
     public static class MyExtensions
     {
+        public static PlainVec3D ToPlain(this Vector3D vector)
+        {
+            return new PlainVec3D(vector);
+        }
+        
         public static bool IsAdminOrCreative(this MySession session)
         {
             // copied from MyCubePlacer.Shoot

--- a/Source/Ivxr.SePlugin/WorldModel/Block.cs
+++ b/Source/Ivxr.SePlugin/WorldModel/Block.cs
@@ -12,7 +12,5 @@
         public PlainVec3D MinPosition;
         public PlainVec3D MaxPosition;
         public PlainVec3D Size;
-        public PlainVec3D OrientationForward;
-        public PlainVec3D OrientationUp;
     }
 }

--- a/Source/Ivxr.SePlugin/WorldModel/Entity.cs
+++ b/Source/Ivxr.SePlugin/WorldModel/Entity.cs
@@ -1,8 +1,7 @@
 ﻿namespace Iv4xr.SePlugin.WorldModel
 {
-    public class Entity
+    public class Entity: Pose
     {
         public string Id;
-        public PlainVec3D Position;
     }
 }

--- a/Source/Ivxr.SePlugin/WorldModel/Observation.cs
+++ b/Source/Ivxr.SePlugin/WorldModel/Observation.cs
@@ -3,17 +3,10 @@
 namespace Iv4xr.SePlugin.WorldModel
 {
     // Intended to be maximally compatible with Iv4xr.framework.world.WorldModel from the iv4XR Java framework.
-    public class Observation
+    public class Observation: Entity
     {
-        public string AgentID;
-
-        public PlainVec3D Position; // Agent's position
-        public PlainVec3D OrientationForward;
-        public PlainVec3D OrientationUp;
         public PlainVec3D Velocity; // Agent's velocity
         public PlainVec3D Extent; // Agent's dimensions (x,y,z size/2)
-
-        public List<Entity> Entities;
 
         public List<CubeGrid> Grids;
     }

--- a/Source/Ivxr.SePlugin/WorldModel/Pose.cs
+++ b/Source/Ivxr.SePlugin/WorldModel/Pose.cs
@@ -1,0 +1,9 @@
+﻿namespace Iv4xr.SePlugin.WorldModel
+{
+    public class Pose
+    {
+        public PlainVec3D Position;
+        public PlainVec3D OrientationForward;
+        public PlainVec3D OrientationUp;
+    }
+}

--- a/Source/Tests/Ivxr.SePlugin.Tests/JsonerTests.cs
+++ b/Source/Tests/Ivxr.SePlugin.Tests/JsonerTests.cs
@@ -33,9 +33,8 @@ namespace Ivxr.SeGameLib.Tests
         {
             var observation = new Observation
             {
-                    AgentID = "Foo",
-                    Position = new PlainVec3D(1, 2, 3),
-                    Entities = new List<Entity>()
+                    Id = "Foo",
+                    Position = new PlainVec3D(1, 2, 3)
             };
 
             var json = m_jsoner.ToJson(observation);


### PR DESCRIPTION
Unifying interface for OrientedPosition (object, that has position and orientation) and Entity (object, that has Id and OrientedPosition).
Currently Observation implements Entity interface, cause fields were like that (just renamed agentId to id), but then I wanna give more structure to Observations returned. But that needs to be done after I remove the old API. This is good middle ground inbetween for now.