### PR TITLE
CucumberTester jitpack configuration.

### DIFF
--- a/CucumberTester/build.gradle
+++ b/CucumberTester/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.multiplatform' version "$kotlin_version" apply(false)
     id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlin_version" apply(false)
+    id 'maven-publish'
 }
 
 group 'com.github.iv4xr-project'
@@ -38,4 +39,16 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId project.group
+            artifactId project.name
+            version project.version
+            from components.java
+        }
+    }
 }


### PR DESCRIPTION
Allows referencing cucumber tester project through jitpack repository:
`implementation("com.github.iv4xr-project.iv4xr-se-plugin:CucumberTester:main-SNAPSHOT")`